### PR TITLE
where() array bug

### DIFF
--- a/sparrow.php
+++ b/sparrow.php
@@ -161,7 +161,8 @@ class Sparrow {
         if (is_string($field)) {
             if ($value === null) return $join.' '.trim($field);
 
-            list($field, $operator) = explode(' ', $field);
+            if (strpos($field, ' '))
+                list($field, $operator) = explode(' ', $field);
 
             if (!empty($operator)) {
                 switch ($operator) {


### PR DESCRIPTION
Using the example in the 'README' file

``` php
$where = array('id' => 123, 'name' => 'bob');

echo $db->from('user')
    ->where($where)
    ->select()
    ->sql();
```

I received a notice:

> Notice: Undefined offset: 1 in sparrow.php on line 164
